### PR TITLE
Use updated Rancher Metadata methods.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -14,7 +14,7 @@
 		},
 		{
 			"ImportPath": "github.com/rancher/go-rancher-metadata/metadata",
-			"Rev": "eb676640a6f61310c798be94dc65121fe90bc6ef"
+			"Rev": "d2c49cce1a7fd3d99c3a3823a21d105256b4ea48"
 		}
 	]
 }

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher-metadata/metadata/metadata.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher-metadata/metadata/metadata.go
@@ -15,6 +15,16 @@ func NewClient(url string) *Client {
 	return &Client{url}
 }
 
+func NewClientAndWait(url string) (*Client, error) {
+	client := &Client{url}
+
+	if err := testConnection(client); err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}
+
 func (m *Client) SendRequest(path string) ([]byte, error) {
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", m.url+path, nil)
@@ -105,6 +115,22 @@ func (m *Client) GetContainers() ([]Container, error) {
 		return containers, err
 	}
 	return containers, nil
+}
+
+func (m *Client) GetServiceContainers(serviceName string, stackName string) ([]Container, error) {
+	var serviceContainers = []Container{}
+	containers, err := m.GetContainers()
+	if err != nil {
+		return serviceContainers, err
+	}
+
+	for _, container := range containers {
+		if container.StackName == stackName && container.ServiceName == serviceName {
+			serviceContainers = append(serviceContainers, container)
+		}
+	}
+
+	return serviceContainers, nil
 }
 
 func (m *Client) GetHosts() ([]Host, error) {

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher-metadata/metadata/types.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher-metadata/metadata/types.go
@@ -7,19 +7,21 @@ type Stack struct {
 }
 
 type Service struct {
-	Name        string            `json:"name"`
-	StackName   string            `json:"stack_name"`
-	Kind        string            `json:"kind"`
-	Hostname    string            `json:"hostname"`
-	Vip         string            `json:"vip"`
-	CreateIndex string            `json:"create_index"`
-	ExternalIps []string          `json:"external_ips"`
-	Sidekicks   []string          `json:"sidekicks"`
-	Containers  []string          `json:"containers"`
-	Ports       []string          `json:"ports"`
-	Labels      map[string]string `json:"labels"`
-	Links       map[string]string `json:"links"`
-	Metadata    map[string]string `json:"metadata"`
+	Scale       int                    `json:"scale"`
+	Name        string                 `json:"name"`
+	StackName   string                 `json:"stack_name"`
+	Kind        string                 `json:"kind"`
+	Hostname    string                 `json:"hostname"`
+	Vip         string                 `json:"vip"`
+	CreateIndex string                 `json:"create_index"`
+	UUID        string                 `json:"uuid"`
+	ExternalIps []string               `json:"external_ips"`
+	Sidekicks   []string               `json:"sidekicks"`
+	Containers  []string               `json:"containers"`
+	Ports       []string               `json:"ports"`
+	Labels      map[string]string      `json:"labels"`
+	Links       map[string]string      `json:"links"`
+	Metadata    map[string]interface{} `json:"metadata"`
 }
 
 type Container struct {

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher-metadata/metadata/utils.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher-metadata/metadata/utils.go
@@ -1,0 +1,19 @@
+package metadata
+
+import (
+	"time"
+)
+
+func testConnection(mdClient *Client) error {
+	var err error
+	maxTime := 20 * time.Second
+
+	for i := 1 * time.Second; i < maxTime; i *= time.Duration(2) {
+		if _, err = mdClient.GetVersion(); err != nil {
+			time.Sleep(i)
+		} else {
+			return nil
+		}
+	}
+	return err
+}

--- a/election/proxy.go
+++ b/election/proxy.go
@@ -26,11 +26,6 @@ func New(client *metadata.Client, port int, command []string) *Watcher {
 }
 
 func (w *Watcher) getLeader() (metadata.Container, bool, error) {
-	selfStack, err := w.client.GetSelfStack()
-	if err != nil {
-		return metadata.Container{}, false, err
-	}
-
 	selfContainer, err := w.client.GetSelfContainer()
 	if err != nil {
 		return metadata.Container{}, false, err
@@ -39,16 +34,15 @@ func (w *Watcher) getLeader() (metadata.Container, bool, error) {
 	index := selfContainer.CreateIndex
 	leader := selfContainer
 
-	containers, err := w.client.GetContainers()
+	containers, err := w.client.GetServiceContainers(
+		selfContainer.ServiceName,
+		selfContainer.StackName,
+	)
 	if err != nil {
 		return metadata.Container{}, false, err
 	}
 
 	for _, container := range containers {
-		if container.CreateIndex < 1 || selfStack.Name != container.StackName {
-			continue
-		}
-
 		if container.CreateIndex < index {
 			index = container.CreateIndex
 			leader = container

--- a/main.go
+++ b/main.go
@@ -37,7 +37,11 @@ func main() {
 }
 
 func appAction(cli *cli.Context) {
-	client := metadata.NewClient(metadataUrl)
+	client, err := metadata.NewClientAndWait(metadataUrl)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
 	w := election.New(client, cli.Int(port), cli.Args())
 
 	if cli.Bool(check) {


### PR DESCRIPTION
Uses the NewClientAndWait method to get metadata client. This will
prevent failures as an entrypoint if there is a delay in metadata
availablity.

Minor refactor of the leader election, to use convenience method
of getting service containers.
